### PR TITLE
remove deprecated cmake_policy

### DIFF
--- a/ar_track_alvar/CMakeLists.txt
+++ b/ar_track_alvar/CMakeLists.txt
@@ -23,8 +23,6 @@ find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(TinyXML REQUIRED)
 
-cmake_policy(SET CMP0046 OLD)
-
 # dynamic reconfigure support
 generate_dynamic_reconfigure_options(cfg/Params.cfg)
 


### PR DESCRIPTION
fixes
```
Warnings   << ar_track_alvar:cmake /home/fxm/projects/default/mojin_ws/logs/ar_track_alvar/build.cmake.000.log                                                                                                                                          
CMake Deprecation Warning at CMakeLists.txt:26 (cmake_policy):
  The OLD behavior for policy CMP0046 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```

ref https://cmake.org/cmake/help/v3.0/policy/CMP0046.html